### PR TITLE
Update the Speaker Deck URL to match the link text

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -38,7 +38,7 @@
               <p>
                 <a href="http://github.com/kdaigle/">github.com/kdaigle</a><br />
                 <a href="http://twitter.com/kdaigle/">twitter.com/kdaigle</a><br />
-                <a href="http://www.speakerdeck.com/kdaigle">speakerdeck.com/kyledaigle</a><br/>
+                <a href="http://www.speakerdeck.com/kyledaigle">speakerdeck.com/kyledaigle</a><br/>
               </p>
             </div>
             <div class="contact">


### PR DESCRIPTION
Was looking at your website and got a 404 when clicking your Speacker Deck link. :grin: 
